### PR TITLE
Implement clipboard-driven cleaning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,9 +130,9 @@ jobs:
 
       - name: Preview build
         run: pnpm preview &
-        
+
       - name: Wait for preview to be ready
         run: sleep 5
 
       - name: Test preview (basic smoke test)
-        run: curl -f http://localhost:4173 || echo "Preview server not responding" 
+        run: curl -f http://localhost:4173 || echo "Preview server not responding"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -118,4 +118,4 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           # This would analyze bundle size changes in PRs
-          echo "Bundle size analysis would be posted as PR comment" 
+          echo "Bundle size analysis would be posted as PR comment"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,8 @@ jobs:
           body: |
             ## 🚀 Deployment
             This release has been automatically deployed to [clean.roga.dev](https://clean.roga.dev) via Vercel.
-            
+
             ## 📋 Changes
             See the full changelog below.
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ AI Text Cleaner detects and removes:
 - **🎯 Precision Detection**: Advanced algorithms detect even subtle hidden markers
 - **📱 Responsive Design**: Works beautifully on desktop and mobile
 - **🎨 Modern UI**: Built with Tailwind CSS and Svelte 5
+- **⚡ One-Step Cleaning**: Paste with **Ctrl+V** to instantly clean and copy text to your clipboard
+- **🔍 Diff Review**: Click "View Changes" to compare your original and cleaned text
 
 ## 🚀 Quick Start
 

--- a/src/lib/components/HighlightedText.svelte
+++ b/src/lib/components/HighlightedText.svelte
@@ -53,7 +53,7 @@
 </script>
 
 <div class="font-mono text-sm leading-relaxed whitespace-pre-wrap">
-	{#each segments as segment}
+	{#each segments as segment, i (i)}
 		{#if segment.isChange && segment.change}
 			<span
 				class="group relative inline-block {segment.change.type === 'whitespace'

--- a/src/lib/utils/textCleaner.ts
+++ b/src/lib/utils/textCleaner.ts
@@ -1,113 +1,129 @@
 export interface CleaningResult {
-  original: string;
-  cleaned: string;
-  changes: TextChange[];
+	original: string;
+	cleaned: string;
+	changes: TextChange[];
 }
 
 export interface TextChange {
-  start: number;
-  end: number;
-  original: string;
-  replacement: string;
-  type: 'whitespace' | 'em-dash' | 'other';
+	start: number;
+	end: number;
+	original: string;
+	replacement: string;
+	type: 'whitespace' | 'em-dash' | 'other';
 }
 
 // Common AI-generated text markers and suspicious whitespace characters
 const SUSPICIOUS_WHITESPACE = [
-  '\u00A0', // Non-breaking space
-  '\u2000', // En quad
-  '\u2001', // Em quad
-  '\u2002', // En space
-  '\u2003', // Em space
-  '\u2004', // Three-per-em space
-  '\u2005', // Four-per-em space
-  '\u2006', // Six-per-em space
-  '\u2007', // Figure space
-  '\u2008', // Punctuation space
-  '\u2009', // Thin space
-  '\u200A', // Hair space
-  '\u200B', // Zero-width space
-  '\u200C', // Zero-width non-joiner
-  '\u200D', // Zero-width joiner
-  '\u202F', // Narrow no-break space
-  '\u205F', // Medium mathematical space
-  '\u3000', // Ideographic space
-  '\uFEFF', // Zero-width no-break space (BOM)
+	'\u00A0', // Non-breaking space
+	'\u2000', // En quad
+	'\u2001', // Em quad
+	'\u2002', // En space
+	'\u2003', // Em space
+	'\u2004', // Three-per-em space
+	'\u2005', // Four-per-em space
+	'\u2006', // Six-per-em space
+	'\u2007', // Figure space
+	'\u2008', // Punctuation space
+	'\u2009', // Thin space
+	'\u200A', // Hair space
+	'\u200B', // Zero-width space
+	'\u200C', // Zero-width non-joiner
+	'\u200D', // Zero-width joiner
+	'\u202F', // Narrow no-break space
+	'\u205F', // Medium mathematical space
+	'\u3000', // Ideographic space
+	'\uFEFF' // Zero-width no-break space (BOM)
 ];
 
 const EM_DASH_REGEX = /—/g;
 
 export function cleanText(text: string): CleaningResult {
-  const changes: TextChange[] = [];
-  let cleaned = text;
+        const changes: TextChange[] = [];
+        let cleaned = text;
 
-  // First, find all em dashes
-  const emDashMatches = [...text.matchAll(EM_DASH_REGEX)];
-  for (const match of emDashMatches) {
-    if (match.index !== undefined) {
-      changes.push({
-        start: match.index,
-        end: match.index + 1,
-        original: '—',
-        replacement: ' - ',
-        type: 'em-dash'
-      });
-    }
-  }
+	// First, find all em dashes
+	const emDashMatches = [...text.matchAll(EM_DASH_REGEX)];
+	for (const match of emDashMatches) {
+		if (match.index !== undefined) {
+			changes.push({
+				start: match.index,
+				end: match.index + 1,
+				original: '—',
+				replacement: ' - ',
+				type: 'em-dash'
+			});
+		}
+	}
 
-  // Then find suspicious whitespace characters
-  for (let i = 0; i < text.length; i++) {
-    const char = text[i];
-    if (SUSPICIOUS_WHITESPACE.includes(char)) {
-      changes.push({
-        start: i,
-        end: i + 1,
-        original: char,
-        replacement: ' ',
-        type: 'whitespace'
-      });
-    }
-  }
+	// Then find suspicious whitespace characters
+	for (let i = 0; i < text.length; i++) {
+		const char = text[i];
+		if (SUSPICIOUS_WHITESPACE.includes(char)) {
+			changes.push({
+				start: i,
+				end: i + 1,
+				original: char,
+				replacement: ' ',
+				type: 'whitespace'
+			});
+		}
+	}
 
-  // Sort changes by position to apply them correctly
-  changes.sort((a, b) => a.start - b.start);
+	// Sort changes by position to apply them correctly
+	changes.sort((a, b) => a.start - b.start);
 
-  // Apply changes from end to beginning to maintain correct indices
-  for (let i = changes.length - 1; i >= 0; i--) {
-    const change = changes[i];
-    cleaned = cleaned.slice(0, change.start) + change.replacement + cleaned.slice(change.end);
-  }
+	// Apply changes from end to beginning to maintain correct indices
+        for (let i = changes.length - 1; i >= 0; i--) {
+                const change = changes[i];
+                cleaned = cleaned.slice(0, change.start) + change.replacement + cleaned.slice(change.end);
+        }
 
-  return {
-    original: text,
-    cleaned,
-    changes
-  };
+       // Remove extra newlines at the end of the text
+       const newlineMatch = cleaned.match(/[\r\n]+$/);
+       if (newlineMatch) {
+               changes.push({
+                       start: cleaned.length - newlineMatch[0].length,
+                       end: cleaned.length,
+                       original: newlineMatch[0],
+                       replacement: '',
+                       type: 'whitespace'
+               });
+               cleaned = cleaned.slice(0, cleaned.length - newlineMatch[0].length);
+       }
+
+	return {
+		original: text,
+		cleaned,
+		changes
+	};
 }
 
 export function getCharacterName(char: string): string {
-  const charMap: Record<string, string> = {
-    '\u00A0': 'Non-breaking space',
-    '\u2000': 'En quad',
-    '\u2001': 'Em quad',
-    '\u2002': 'En space',
-    '\u2003': 'Em space',
-    '\u2004': 'Three-per-em space',
-    '\u2005': 'Four-per-em space',
-    '\u2006': 'Six-per-em space',
-    '\u2007': 'Figure space',
-    '\u2008': 'Punctuation space',
-    '\u2009': 'Thin space',
-    '\u200A': 'Hair space',
-    '\u200B': 'Zero-width space',
-    '\u200C': 'Zero-width non-joiner',
-    '\u200D': 'Zero-width joiner',
-    '\u202F': 'Narrow no-break space',
-    '\u205F': 'Medium mathematical space',
-    '\u3000': 'Ideographic space',
-    '\uFEFF': 'Zero-width no-break space (BOM)',
-    '—': 'Em dash'
-  };
+	const charMap: Record<string, string> = {
+		'\u00A0': 'Non-breaking space',
+		'\u2000': 'En quad',
+		'\u2001': 'Em quad',
+		'\u2002': 'En space',
+		'\u2003': 'Em space',
+		'\u2004': 'Three-per-em space',
+		'\u2005': 'Four-per-em space',
+		'\u2006': 'Six-per-em space',
+		'\u2007': 'Figure space',
+		'\u2008': 'Punctuation space',
+		'\u2009': 'Thin space',
+		'\u200A': 'Hair space',
+		'\u200B': 'Zero-width space',
+		'\u200C': 'Zero-width non-joiner',
+		'\u200D': 'Zero-width joiner',
+		'\u202F': 'Narrow no-break space',
+		'\u205F': 'Medium mathematical space',
+		'\u3000': 'Ideographic space',
+		'\uFEFF': 'Zero-width no-break space (BOM)',
+		'—': 'Em dash'
+	};
 
-  return charMap[char] || `Unknown character (U+${char.charCodeAt(0).toString(16).toUpperCase().padStart(4, '0')})`;
-} 
+	return (
+		charMap[char] ||
+		`Unknown character (U+${char.charCodeAt(0).toString(16).toUpperCase().padStart(4, '0')})`
+	);
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,8 +7,9 @@
 	let showInfo = $state(true);
 	let isProcessing = $state(false);
 	let copySuccess = $state(false);
+	let showDiff = $state(false);
 
-	function handleClean() {
+	function handleClean(autoCopy = false) {
 		if (!inputText.trim()) return;
 
 		isProcessing = true;
@@ -16,6 +17,9 @@
 		setTimeout(() => {
 			cleaningResult = cleanText(inputText);
 			isProcessing = false;
+			if (autoCopy) {
+				copyCleanText();
+			}
 		}, 100);
 	}
 
@@ -39,6 +43,15 @@
 		copySuccess = false;
 	}
 
+	function handlePaste(event: ClipboardEvent) {
+		const pasted = event.clipboardData?.getData('text');
+		if (!pasted) return;
+		event.preventDefault();
+		inputText = pasted;
+		handleClean(true);
+		showDiff = false;
+	}
+
 	let changeCount = $derived(cleaningResult?.changes.length ?? 0);
 	let hasChanges = $derived(changeCount > 0);
 </script>
@@ -50,6 +63,8 @@
 		content="Clean AI-generated text by removing hidden whitespace markers and formatting inconsistencies that identify generated content."
 	/>
 </svelte:head>
+
+<svelte:window on:paste={handlePaste} />
 
 <div class="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50">
 	<!-- Navigation/Header Bar -->
@@ -309,7 +324,7 @@ This tool analyzes your text for:
 						</div>
 
 						<div class="p-6">
-							{#if hasChanges}
+							{#if hasChanges && showDiff}
 								<div
 									class="mb-6 overflow-hidden rounded-lg border border-gray-200 bg-gradient-to-br from-gray-50 to-gray-100"
 								>
@@ -325,7 +340,8 @@ This tool analyzes your text for:
 										/>
 									</div>
 								</div>
-							{:else}
+							{/if}
+							{#if !hasChanges}
 								<div
 									class="mb-6 rounded-lg border border-green-200 bg-gradient-to-br from-green-50 to-emerald-50 p-4"
 								>
@@ -349,6 +365,15 @@ This tool analyzes your text for:
 										</div>
 									</div>
 								</div>
+							{/if}
+
+							{#if hasChanges}
+								<button
+									onclick={() => (showDiff = !showDiff)}
+									class="mb-4 inline-flex items-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all duration-200 hover:bg-gray-50 focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:outline-none"
+								>
+									{showDiff ? 'Hide Changes' : 'View Changes'}
+								</button>
 							{/if}
 
 							<button


### PR DESCRIPTION
## Summary
- let Prettier clean up YAML and TS files
- display diff segments with an `each` key
- copy cleaned text automatically and handle Ctrl+V paste events
- allow toggling diff display
- mention one-step cleaning in docs
- trim stray newlines when cleaning

## Testing
- `pnpm lint` *(fails: Cannot find package 'prettier-plugin-svelte')*

------
https://chatgpt.com/codex/tasks/task_e_6840c80b5c648329beb4c8dbaefa54a9