### PR TITLE
Update cleaner UI with collapsible sections

### DIFF
--- a/src/lib/utils/textCleaner.ts
+++ b/src/lib/utils/textCleaner.ts
@@ -38,8 +38,8 @@ const SUSPICIOUS_WHITESPACE = [
 const EM_DASH_REGEX = /—/g;
 
 export function cleanText(text: string): CleaningResult {
-        const changes: TextChange[] = [];
-        let cleaned = text;
+	const changes: TextChange[] = [];
+	let cleaned = text;
 
 	// First, find all em dashes
 	const emDashMatches = [...text.matchAll(EM_DASH_REGEX)];
@@ -73,23 +73,23 @@ export function cleanText(text: string): CleaningResult {
 	changes.sort((a, b) => a.start - b.start);
 
 	// Apply changes from end to beginning to maintain correct indices
-        for (let i = changes.length - 1; i >= 0; i--) {
-                const change = changes[i];
-                cleaned = cleaned.slice(0, change.start) + change.replacement + cleaned.slice(change.end);
-        }
+	for (let i = changes.length - 1; i >= 0; i--) {
+		const change = changes[i];
+		cleaned = cleaned.slice(0, change.start) + change.replacement + cleaned.slice(change.end);
+	}
 
-       // Remove extra newlines at the end of the text
-       const newlineMatch = cleaned.match(/[\r\n]+$/);
-       if (newlineMatch) {
-               changes.push({
-                       start: cleaned.length - newlineMatch[0].length,
-                       end: cleaned.length,
-                       original: newlineMatch[0],
-                       replacement: '',
-                       type: 'whitespace'
-               });
-               cleaned = cleaned.slice(0, cleaned.length - newlineMatch[0].length);
-       }
+	// Remove extra newlines at the end of the text
+	const newlineMatch = cleaned.match(/[\r\n]+$/);
+	if (newlineMatch) {
+		changes.push({
+			start: cleaned.length - newlineMatch[0].length,
+			end: cleaned.length,
+			original: newlineMatch[0],
+			replacement: '',
+			type: 'whitespace'
+		});
+		cleaned = cleaned.slice(0, cleaned.length - newlineMatch[0].length);
+	}
 
 	return {
 		original: text,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,6 +20,7 @@
 		setTimeout(async () => {
 			cleaningResult = cleanText(inputText);
 			isProcessing = false;
+			// Automatically copy the cleaned text to the clipboard
 			await copyCleanText();
 			inputCollapsed = true;
 			showResults = false;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -70,7 +70,7 @@
 	/>
 </svelte:head>
 
-<svelte:window on:paste={handlePaste} />
+<svelte:window onpaste={handlePaste} />
 
 <div class="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50">
 	<!-- Navigation/Header Bar -->
@@ -182,9 +182,9 @@
 							<h2 class="text-lg font-semibold text-gray-900">Input Text</h2>
 						</div>
 						{#if inputCollapsed}
-							<button class="text-sm text-blue-600" on:click={() => (inputCollapsed = false)}
-								>Expand</button
-							>
+							<button class="text-sm text-blue-600" onclick={() => (inputCollapsed = false)}>
+								Expand
+							</button>
 						{/if}
 					</div>
 
@@ -285,7 +285,7 @@ This tool analyzes your text for:
 							{#if cleaningResult}
 								<button
 									class="mt-4 w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all duration-200 hover:bg-gray-50 focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:outline-none"
-									on:click={() => (showResults = !showResults)}
+									onclick={() => (showResults = !showResults)}
 								>
 									{showResults ? 'Hide Cleaning Results' : 'Show Cleaning Results'}
 								</button>
@@ -345,9 +345,9 @@ This tool analyzes your text for:
 										{/if}
 									</div>
 								</div>
-								<button class="text-sm text-blue-600" on:click={() => (showResults = false)}
-									>Hide</button
-								>
+								<button class="text-sm text-blue-600" onclick={() => (showResults = false)}>
+									Hide
+								</button>
 							</div>
 
 							<div class="p-6">
@@ -412,7 +412,7 @@ This tool analyzes your text for:
 
 								{#if hasChanges}
 									<button
-										on:click={() => (showDiff = !showDiff)}
+										onclick={() => (showDiff = !showDiff)}
 										class="mb-4 inline-flex items-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all duration-200 hover:bg-gray-50 focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:outline-none"
 									>
 										{showDiff ? 'Hide Changes' : 'View Changes'}
@@ -421,7 +421,7 @@ This tool analyzes your text for:
 
 								<div class="mt-4 flex items-center justify-between">
 									<button
-										on:click={copyCleanText}
+										onclick={copyCleanText}
 										class="group inline-flex items-center rounded-lg bg-gradient-to-r from-green-600 to-emerald-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition-all duration-200 hover:from-green-700 hover:to-emerald-700 focus:ring-2 focus:ring-green-600 focus:ring-offset-2 focus:outline-none"
 									>
 										{#if copySuccess}
@@ -452,7 +452,7 @@ This tool analyzes your text for:
 										{/if}
 									</button>
 									<button
-										on:click={() => (showResults = false)}
+										onclick={() => (showResults = false)}
 										class="inline-flex items-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all duration-200 hover:bg-gray-50 focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:outline-none"
 										>Hide Results</button
 									>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -345,7 +345,13 @@ This tool analyzes your text for:
 										{/if}
 									</div>
 								</div>
-								<button class="text-sm text-blue-600" onclick={() => (showResults = false)}>
+								<button
+									class="text-sm text-blue-600"
+									onclick={() => {
+										showResults = false;
+										showDiff = false;
+									}}
+								>
 									Hide
 								</button>
 							</div>
@@ -452,7 +458,10 @@ This tool analyzes your text for:
 										{/if}
 									</button>
 									<button
-										onclick={() => (showResults = false)}
+										onclick={() => {
+											showResults = false;
+											showDiff = false;
+										}}
 										class="inline-flex items-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-all duration-200 hover:bg-gray-50 focus:ring-2 focus:ring-blue-600 focus:ring-offset-2 focus:outline-none"
 										>Hide Results</button
 									>


### PR DESCRIPTION
## Summary
- update page logic to automatically copy cleaned text and collapse input
- add ability to show/hide cleaning results with transitions
- adjust layout to single column with improved controls

## Testing
- `pnpm exec prettier --write src/routes/+page.svelte`
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840cd6451688329afc09d1e955a9502